### PR TITLE
remove hardcoded env variables for run handler

### DIFF
--- a/core/ruby2.5Action/rackapp/run.rb
+++ b/core/ruby2.5Action/rackapp/run.rb
@@ -14,9 +14,11 @@ class RunApp
     body = Rack::Request.new(env).body.read
     data = JSON.parse(body) || {}
     env = {'BUNDLE_GEMFILE' => PROGRAM_DIR + 'Gemfile'}
-    ['api_key', 'namespace', 'action_name', 'activation_id', 'deadline'].each{|e|
-      env["__OW_#{e.upcase}"] = data[e] if data[e] && data[e].is_a?(String)
-    }
+    data.each do |key, value|
+      if key != 'value'
+        env["__OW_#{key.upcase}"] = value if value && value.is_a?(String)
+      end
+    end
 
     # Save parameter values to file in order to let runner.rb read this later
     File.write PARAM, data['value'].to_json


### PR DESCRIPTION
This allows for the customized invoker with an SPI to send more variables in the run handler
@eweiter could you review this PR.